### PR TITLE
fix for more maintainability and portability (mainly for MSVS):

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -29,3 +29,7 @@
 #zlib_dir = /usr
 # install man pages for command line utilities here
 #man_dir = /usr/local/man
+[files]
+# uncomment and set to grib_api library name.
+# If you are using GRIB-API with MSVS, library name might be 'grib_api_lib'.
+#grib_api_libname = grib_api_lib


### PR DESCRIPTION
Now, ECMWF GRIB-API start supporting MSVS (see https://software.ecmwf.int/wiki/pages/viewpage.action?pageId=48109524), so let us start supporting MSVS. 

1. avoid os.sep sensitive (-> use os.path.join)
2. ability to change grib_api library name with setup.cfg
3. editing pyx  to make sense.
4. class _ConfigParser to maintainability

I don't fix 'inttypes.h' problem with MSVS8 (MSVC9), but fix-3 will help us to fix manually.
