### PR TITLE
Fix for python3 (broken index positions)

### DIFF
--- a/g2clib.pyx
+++ b/g2clib.pyx
@@ -174,7 +174,7 @@ def unpack1(gribmsg, ipos, object zeros):
        raise RuntimeError(msg)
 
     idsect = _toarray(ids, zeros(idslen, 'i4'))
-    return idsect,iofst/8
+    return idsect,iofst//8
 
 
 
@@ -238,7 +238,7 @@ def unpack3(gribmsg, ipos, object zeros):
     gds = _toarray(igds, zeros(5, 'i4'))
     deflist = _toarray(ideflist, zeros(idefnum, 'i4'))
 
-    return gds,gdtmpl,deflist,iofst/8
+    return gds,gdtmpl,deflist,iofst//8
 
 def unpack4(gribmsg,ipos,object zeros):
     """
@@ -288,7 +288,7 @@ def unpack4(gribmsg,ipos,object zeros):
     pdtmpl = _toarray(ipdstmpl, zeros(mappdslen, 'i4'))
     coordlist = _toarray(icoordlist, zeros(numcoord, 'f4'))
 
-    return pdtmpl,ipdsnum,coordlist,iofst/8
+    return pdtmpl,ipdsnum,coordlist,iofst//8
     
 def unpack5(gribmsg,ipos,object zeros):
     """
@@ -332,7 +332,7 @@ def unpack5(gribmsg,ipos,object zeros):
        raise RuntimeError(msg)
 
     drtmpl = _toarray(idrstmpl, zeros(mapdrslen, 'i4'))
-    return drtmpl,idrsnum,ndpts,iofst/8
+    return drtmpl,idrsnum,ndpts,iofst//8
     
 def unpack6(gribmsg,ndpts,ipos,object zeros):
     """


### PR DESCRIPTION
The decode$() methods were dividing by 8 when returning the pos using the python '/' operator.  In python3 (for whatever reason) this now "upgrades" the value to a float.  The pos (which is now a float) is used as an index and blows up with a TypeError.

  This fix changes the division to a '//' operator which keeps the value as an int.  This should work for all versions of python actually supported by the python developers (2.7+).