### PR TITLE
install numpy as a setup dependency; added pyproj to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class _ConfigParser(configparser.SafeConfigParser):
 
 NUMPY_VERSION = ">= 1.9.3"
 install_requires = [
-  "numpy{}".format(NUMPY_VERSION),
+  "numpy{0}".format(NUMPY_VERSION),
 ]
 
 # numpy must be installed before setup() starts. This is a common problem
@@ -28,10 +28,10 @@ except ImportError:
     except ImportError:
         print("\nCould not automatically install numpy. Please install it "
               "manually by typing:\n\n"
-              "pip install numpy{}\n".format(NUMPY_VERSION))
+              "pip install numpy{0}\n".format(NUMPY_VERSION))
         sys.exit(1)
     else:
-        exitcode = pip.main(["install", "numpy{}".format(NUMPY_VERSION)])
+        exitcode = pip.main(["install", "numpy{0}".format(NUMPY_VERSION)])
         import numpy
 
 # pyproj is a runtime dependency

--- a/setup.py
+++ b/setup.py
@@ -225,4 +225,5 @@ setup(name = "pygrib",
       scripts           = install_scripts,
       ext_modules       = install_ext_modules,
       py_modules        = install_py_modules,
+      install_requires  = install_requires,
       data_files        = data_files)


### PR DESCRIPTION
This PR solves issue https://github.com/jswhit/pygrib/issues/13.

It's been a long standing problem of pygrib that it cannot be installed without manually installing numpy and pyproj beforehand.
Installing numpy with respect to C extensions is a known issue and many projects suffer from it. The proposed solution is, supposedly, one of the cleaner ones.