### PR TITLE
Updated setup.py to force install of redtoregext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -175,11 +175,14 @@ install_py_modules = []
 
 if "pygrib" in packages_to_install:
     install_scripts += ['utils/grib_list','utils/grib_repack','utils/cnvgrib1to2','utils/cnvgrib2to1']
-    install_ext_modules += [pygribext,redtoregext]
+    install_ext_modules += [pygribext]
 
 if "ncepgrib2" in packages_to_install:
     install_ext_modules += [g2clibext]
     install_py_modules += ["ncepgrib2"]
+
+# Must install redtoregext
+install_ext_modules += [redtoregext]
 
 setup(name = "pygrib",
       version = "2.0.2",


### PR DESCRIPTION
I have updated setup.py to force install of redtoregext module which is needed for both pygrib and/or ncepgrib2.