### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,7 @@ recursive-include docs *
 recursive-include ports *
 recursive-include ncepgrib2_docs *
 include sampledata/*.grb
+include sampledata/*.grb2
 include sampledata/*.grib*
 include sampledata/*.bin
 recursive-include g2clib_src *


### PR DESCRIPTION
also include datafiles having grb2 extension, so sampledata/no-radius-shapeOfEarth-7.grb2 will also be included.

Actually, this missing data file causes the unittests from the test.py script to fail for me for both python2 and python3, for release 2.0.3 ....