### PR TITLE
Future secure pygrib

### DIFF
--- a/ncepgrib2.py
+++ b/ncepgrib2.py
@@ -1109,7 +1109,7 @@ def Grib2Decode(filename,gribmsg=False):
             kwargs['center_wmo_code']=wmo_code
         kwargs['grid_definition_template_number']=gdtnum[n]
         kwargs['grid_definition_template']=gdtmpl[n]
-        if gdeflist[n] != []:
+        if gdeflist[n].size > 0:
             kwargs['grid_definition_list']=gdeflist[n]
         kwargs['grid_definition_info']=gdsinfo[n]
         kwargs['discipline_code']=discipline[n]
@@ -1117,7 +1117,7 @@ def Grib2Decode(filename,gribmsg=False):
         kwargs['product_definition_template']=pdtmpl[n]
         kwargs['data_representation_template_number']=drtnum[n]
         kwargs['data_representation_template']=drtmpl[n]
-        if coordlist[n] != []:
+        if coordlist[n].size > 0:
             kwargs['extra_vertical_coordinate_info']=coordlist[n]
         kwargs['number_of_data_points_to_unpack']=ndpts[n]
         kwargs['bitmap_indicator_flag']=bitmapflag[n]


### PR DESCRIPTION
Current version of pygrib emits the following warnings:

```
ncepgrib2.py:1112: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
  if gdeflist[n] != []:
ncepgrib2.py:1120: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
  if coordlist[n] != []:
```
This changes those lines to make the suggested comparison instead.

I ran the test suite of my change and they passed, I also tested the update against our use of pygrib and our tests passed as well, and the warnings disappeared.