### PR TITLE
Simplified `_flatten`

### DIFF
--- a/ncepgrib2.py
+++ b/ncepgrib2.py
@@ -3,6 +3,7 @@ import g2clib
 import struct
 import string
 import math
+import functools
 import warnings
 import operator
 from datetime import datetime
@@ -1214,12 +1215,7 @@ def _repeatlast(numfields,listin):
     return listin
 
 def _flatten(lst):
-    try:
-        flist = functools.reduce(operator.add,lst)
-    except NameError: # no reduce in python 3.
-        import functools
-        flist = functools.reduce(operator.add,lst)
-    return flist
+    return functools.reduce(operator.add,lst)
 
 
 class Grib2Encode:


### PR DESCRIPTION
The comment in the function seems strange since `functools.reduce` exists in python 3. For either python 2 or 3 `functools` would not have been imported on the first execution. And if there was a discrepancy between early versions of python 3 and 2 the code had no handling of such since the code in the except is identical to the one in the try. I'm guessing it was an output of an automated python 2 -> python 3 tool?

I ran the test suite of my change and they passed, I also tested the update against our use of pygrib and our tests passed as well, so it seems the old code didn't do anything.