### PR TITLE
Add shapeOfTheEarth 4, assumed oblate spheroid as defined in IAG-GRS8…

### DIFF
--- a/pygrib.pyx
+++ b/pygrib.pyx
@@ -1448,6 +1448,9 @@ cdef class gribmessage(object):
                 else:
                     projparams['a']=self['scaledValueOfEarthMajorAxis']*scalea
                     projparams['b']=self['scaledValueOfEarthMinorAxis']*scaleb
+            elif self['shapeOfTheEarth'] == 4:
+                projparams['a']=6378137.0
+                projparams['b']=6356752.314
             elif self['shapeOfTheEarth'] == 2:
                 projparams['a']=6378160.0
                 projparams['b']=6356775.0 


### PR DESCRIPTION
http://apps.ecmwf.int/codes/grib/format/grib2/ctables/3/2
> 4 | Earth assumed oblate spheroid as defined in IAG-GRS80 model (major axis = 6,378,137.0 m, minor axis = 6,356,752.314 m, f = 1/298.257222101)