### PR TITLE
fix for computation of gaussian latitudes #102

### DIFF
--- a/pygrib.pyx
+++ b/pygrib.pyx
@@ -1598,20 +1598,22 @@ cdef class gribmessage(object):
             # workaround for grib_api bug with complex packing.
             # (distinctLongitudes, distinctLatitudes throws error,
             #  so use np.linspace to define values)
-            if self.packingType.startswith('grid_complex'):
-                # this is not strictly correct for gaussian grids,
-                # but the error is very small.
-                lats = np.linspace(lat1,lat2,ny)
-                lons = np.linspace(lon1,lon2,nx)
-            else:
-                lats = self['distinctLatitudes']
-                if lat2 < lat1 and lats[-1] > lats[0]: lats = lats[::-1]
-                lons = self['distinctLongitudes']
+            #if self.packingType.startswith('grid_complex'):
+            #    # this is not strictly correct for gaussian grids,
+            #    # but the error is very small.
+            #    lats = np.linspace(lat1,lat2,ny)
+            #    lons = np.linspace(lon1,lon2,nx)
+            #else:
+            # this workaround no longer needed (issue #102)
+            lats = self['distinctLatitudes']
+            if lat2 < lat1 and lats[-1] > lats[0]: lats = lats[::-1]
+            lons = self['distinctLongitudes']
             # don't trust distinctLongitudes 
             # when longitudeOfLastGridPointInDegrees < 0
             # (bug in grib_api 1.9.16)
-            if lon2 < 0:
-                lons = np.linspace(lon1,lon2,nx)
+            # this workaround no longer neede (issue #102)
+            #if lon2 < 0:
+            #    lons = np.linspace(lon1,lon2,nx)
             lons,lats = np.meshgrid(lons,lats) 
         elif self['gridType'] == 'reduced_gg': # reduced global gaussian grid
             if self.expand_reduced:

--- a/pygrib.pyx
+++ b/pygrib.pyx
@@ -1585,16 +1585,16 @@ cdef class gribmessage(object):
             raise ValueError('unsupported grid %s' % self['gridType'])
 
         if self['gridType'] in ['regular_gg','regular_ll']: # regular lat/lon grid
-            nx = self['Ni']
-            ny = self['Nj']
-            lon1 = self['longitudeOfFirstGridPointInDegrees']
-            lon2 = self['longitudeOfLastGridPointInDegrees']
-            if lon1 >= 0 and lon2 < 0 and self.iDirectionIncrement > 0:
-                lon2 = 360+lon2
-            if lon1 >= 0 and lon2 < lon1 and self.iDirectionIncrement > 0:
-                lon1 = lon1-360
-            lat1 = self['latitudeOfFirstGridPointInDegrees']
-            lat2 = self['latitudeOfLastGridPointInDegrees']
+            #nx = self['Ni']
+            #ny = self['Nj']
+            #lon1 = self['longitudeOfFirstGridPointInDegrees']
+            #lon2 = self['longitudeOfLastGridPointInDegrees']
+            #if lon1 >= 0 and lon2 < 0 and self.iDirectionIncrement > 0:
+            #    lon2 = 360+lon2
+            #if lon1 >= 0 and lon2 < lon1 and self.iDirectionIncrement > 0:
+            #    lon1 = lon1-360
+            #lat1 = self['latitudeOfFirstGridPointInDegrees']
+            #lat2 = self['latitudeOfLastGridPointInDegrees']
             # workaround for grib_api bug with complex packing.
             # (distinctLongitudes, distinctLatitudes throws error,
             #  so use np.linspace to define values)


### PR DESCRIPTION
removes workarounds added for bugs in older versions of grib-api that led to inaccurate computation of gaussian latitudes under certain conditions.