### PR TITLE
Allow ncepgrib2.Grib2Message.grid() to work without pygrib (except for Gaussian grids)

### DIFF
--- a/ncepgrib2.py
+++ b/ncepgrib2.py
@@ -756,7 +756,6 @@ lat/lon values returned by grid method may be incorrect."""
  @return: C{B{lats},B{lons}}, float32 numpy arrays
  containing latitudes and longitudes of grid (in degrees).
         """
-        from pygrib import gaulats
         gdsinfo = self.grid_definition_info
         gdtnum = self.grid_definition_template_number
         gdtmpl = self.grid_definition_template
@@ -779,6 +778,10 @@ lat/lon values returned by grid method may be incorrect."""
             projparams['proj'] = 'cyl'
             lons,lats = np.meshgrid(lons,lats) # make 2-d arrays.
         elif gdtnum == 40: # gaussian grid (only works for global!)
+            try:
+                from pygrib import gaulats
+            except:
+                raise ImportError("pygrib required to compute Gaussian lats/lons")
             lon1, lat1 = self.longitude_first_gridpoint, self.latitude_first_gridpoint
             lon2, lat2 = self.longitude_last_gridpoint, self.latitude_last_gridpoint
             nlats = self.points_in_y_direction

--- a/setup.py
+++ b/setup.py
@@ -182,8 +182,11 @@ if "pygrib" in packages_to_install:
     install_ext_modules += [pygribext,redtoregext]
 
 if "ncepgrib2" in packages_to_install:
-    install_ext_modules += [g2clibext]
+    install_ext_modules += [g2clibext,redtoregext]
     install_py_modules += ["ncepgrib2"]
+
+# Make sure only 1 instance of redtoregext exists in install_ext_modules
+install_ext_modules = list(set(install_ext_modules))
 
 setup(name = "pygrib",
       version = "2.0.4",


### PR DESCRIPTION
Moved import of pygrib.gaulats to inside elif gdtnum == 40 since no other condition relies on gaulats