### PR TITLE
Update setup.py to properly install numpy/pyproj

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup, Extension
 import os, glob, sys
 from os import environ
+
 if sys.version_info[0] < 3:
     import ConfigParser as configparser
 else:
@@ -13,29 +14,31 @@ class _ConfigParser(configparser.SafeConfigParser):
         except:
             return fallback
 
-# pyproj is a runtime dependency
-try:
-    import pyproj
-except ImportError:
-    try:
-        from mpl_toolkits.basemap import pyproj
-    except:
-        raise ImportError("either pyproj or basemap required")
-
 # build time dependancy
 try:
     from Cython.Distutils import build_ext
-    #from Cython.Build import cythonize
-    cmdclass = {'build_ext': build_ext}
     pygrib_pyx = "pygrib.pyx"
     redtoreg_pyx = "redtoreg.pyx"
     g2clib_pyx  = 'g2clib.pyx'
 except ImportError:
-    cmdclass = {}
+    from distutils.command.build_ext import build_ext
     pygrib_pyx = "pygrib.c"
     redtoreg_pyx = "redtoreg.c"
     g2clib_pyx  = 'g2clib.c'
 
+class NumpyBuildExtCommand(build_ext):
+    """
+    build_ext command for use when numpy headers are needed.
+    from https://stackoverflow.com/questions/2379898/
+    and https://stackoverflow.com/questions/48283503/
+    """
+    def run(self):
+        self.distribution.fetch_build_eggs(['numpy'])
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        build_ext.run(self)
+
+cmdclass = {'build_ext': NumpyBuildExtCommand}
 
 setup_cfg = environ.get('PYGRIBSETUPCFG', 'setup.cfg')
 config = _ConfigParser()
@@ -91,8 +94,8 @@ if "pygrib" in packages_to_install and \
 
 libraries=[]
 libdirs=[]
-import numpy
-incdirs=[numpy.get_include()]
+incdirs=[]
+
 if "pygrib" in packages_to_install: libraries+=[grib_api_libname]
 
 if grib_api_libdir is None and grib_api_dir is not None:
@@ -160,7 +163,7 @@ else:
 g2clibext = Extension("g2clib",g2clib_deps,include_dirs=incdirs,\
             library_dirs=libdirs,libraries=libraries,runtime_library_dirs=libdirs,define_macros=macros)
 redtoregext =\
-Extension("redtoreg",[redtoreg_pyx],include_dirs=[numpy.get_include()])
+Extension("redtoreg",[redtoreg_pyx])
 pygribext =\
 Extension("pygrib",[pygrib_pyx],include_dirs=incdirs,library_dirs=libdirs,\
           runtime_library_dirs=libdirs,libraries=libraries)
@@ -185,8 +188,18 @@ if "ncepgrib2" in packages_to_install:
     install_ext_modules += [g2clibext,redtoregext]
     install_py_modules += ["ncepgrib2"]
 
-# Make sure only 1 instance of redtoregext exists in install_ext_modules
 install_ext_modules = list(set(install_ext_modules))
+
+install_requires = ["numpy"]
+
+# pyproj is a runtime dependency
+try:
+    import pyproj
+except ImportError:
+    try:
+        from mpl_toolkits.basemap import pyproj
+    except:
+        install_requires.append("pyproj")
 
 setup(name = "pygrib",
       version = "2.0.4",
@@ -214,4 +227,4 @@ setup(name = "pygrib",
       ext_modules       = install_ext_modules,
       py_modules        = install_py_modules,
       data_files        = data_files,
-      install_requires  = ["numpy"])
+      install_requires  = install_requires)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import setuptools
 from distutils.core import setup, Extension
 import os, glob, sys
 from os import environ


### PR DESCRIPTION
This PR reworks `setup.py` to fetch numpy before using it, and adds `pyproj` to the `install_requires` list if it is not already present in one form or another.

Addresses #97 