### PR TITLE
migrate Linux x64 CI build to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Install and Test
+on: [push, pull_request]
+jobs:
+  build-linux:
+    name: Python (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    env:
+      PROJ_DIR: /usr
+      PROJ_LIB: /usr/share/proj
+    strategy:
+      matrix:
+        python-version: ["2.7", "3.7", "3.8"]
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Ubuntu Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install libproj-dev proj-bin libeccodes-dev
+
+    - name: Update Pip
+      run: |
+        python -m pip install --upgrade pip
+
+    - name: Install pygrib dependencies via pip
+      run: |
+        python -m pip install cython numpy "pyproj<3.0.0"
+
+    - name: Install pygrib
+      run: |
+        python setup.py install
+
+    - name: Test
+      run: |
+        python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: focal
 sudo: false
 
 arch:
- - amd64
  - ppc64le
 
 addons:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Linux Build Status](https://travis-ci.org/jswhit/pygrib.svg?branch=master)](https://travis-ci.org/jswhit/pygrib)
+[![Linux Build Status](https://github.com/jswhit/pygrib/workflows/Install%20and%20Test/badge.svg)](https://github.com/jswhit/pygrib/actions)
 [![PyPI package](https://badge.fury.io/py/pygrib.svg)](http://python.org/pypi/pygrib)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pygrib/badges/version.svg)](https://anaconda.org/conda-forge/pygrib)
 [![DOI](https://zenodo.org/badge/28599617.svg)](https://zenodo.org/badge/latestdoi/28599617)


### PR DESCRIPTION
This migrates the Linux x64 build from Travis-CI to Github Actions.  I noticed that the present Travis-CI builds are not properly using different python versions, whilst this Github Actions one should be.  Python 3.9 was dropped for this PR as there are proj version complications to deal with at a later date.

refs #157 