### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import setuptools
 from Cython.Distutils import build_ext
 


### PR DESCRIPTION
setup.py currently fails in case the MAN_DIR env setting is defined. An import glob is needed to fix this.