### PR TITLE
fix for issue #177

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,8 @@ version 2.1.4 (not yet released)
 * update some cartopy test scripts to remove deprecation warnings.
 * move package under 'src' dir so import pygrib works in install dir.
 * add windows and macos x tests.
+* make sure gribmessage.__repr__ doesn't fail is shapeOfTheEarth parameter
+  is missing (issue #177).
 
 version 2.1.3 (git tag v2.1.3rel)
 ================================

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -1325,7 +1325,7 @@ cdef class gribmessage(object):
         if self.has_key('radius'):
             projparams['a'] = self['radius']
             projparams['b'] = self['radius']
-        else:
+        elif self.has_key('shapeOfTheEarth'):
             if self['shapeOfTheEarth'] == 6:
                 projparams['a']=6371229.0
                 projparams['b']=6371229.0


### PR DESCRIPTION
ensures that gribmessage.__repr__ doesn't fail if shapeOfTheEarth key is missing.