### PR TITLE
Added eccodes path for M1 macs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ searchdirs += [
     "/usr",
     "/usr/local",
     "/opt/local",
+    "/opt/homebrew",
     "/opt",
     "/sw",
 ]


### PR DESCRIPTION
Hi,

I had some trouble installing pygrib on my M1 mac, and i realized that it was because homebrew installs the eccodes in `/opt/homebrew` on [M1 macs](https://docs.brew.sh/Installation).  instead of `/usr/local` on intel macs.

Workaround in the meantime is to use the `ECCODES_DIR` environment variable:
```
export ECCODES_DIR="/opt/homebrew"
```