### PR TITLE
Allow `pygrib.open()` to open the path specified by the Path object

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,8 @@
 since version 2.1.4 release
 ===========================
 * add __dir__ method so dir(grb) returns grib keys.
+* allow pygrib.open() to open the path specified by the pathlib.Path object
+  (issue #193, PR #204)
 
 version 2.1.4 (git tag v2.1.4rel)
 ================================

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -7,6 +7,7 @@ cimport numpy as npc
 import warnings
 import os
 from datetime import datetime
+from pathlib import Path
 from pkg_resources import parse_version
 from numpy import ma
 import pyproj
@@ -288,9 +289,9 @@ def get_definitions_path():
 
 cdef class open(object):
     """ 
-    open(filename)
+    open(filename_or_path)
 
-    returns GRIB file iterator object given GRIB filename. When iterated, returns
+    returns GRIB file iterator object given GRIB filename or a Path object. When iterated, returns
     instances of the :py:class:`gribmessage` class. Behaves much like a python file
     object, with :py:meth:`seek`, :py:meth:`tell`, :py:meth:`read`
     :py:meth:`readline` and :py:meth:`close` methods
@@ -317,6 +318,8 @@ cdef class open(object):
         # initialize C level objects.
         cdef grib_handle *gh
         cdef FILE *_fd
+        if isinstance(filename, Path):
+            filename = str(filename)
         bytestr = _strencode(filename)
         self._fd = fopen(bytestr, "rb") 
         if self._fd == NULL:
@@ -326,7 +329,10 @@ cdef class open(object):
         cdef int err, ncount
         cdef grib_handle *gh
         # initalize Python level objects
-        self.name = filename
+        if isinstance(filename, Path):
+            self.name = str(filename)
+        else:
+            self.name = filename
         self.closed = False
         self.messagenumber = 0
         # count number of messages in file.

--- a/test/test.py
+++ b/test/test.py
@@ -239,6 +239,11 @@ def test():
     >>> str(grb.packingType)
     'grid_simple'
     >>> grbs.close()
+
+    test opening a file specified by a pathlib.Path object
+    >>> from pathlib import Path
+    >>> grbs = pygrib.open(Path.cwd().parent / 'sampledata' / 'flux.grb')
+    >>> assert type(grbs.name) == str
     """
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

This PR enhances `pygrib.open()` to open the path specified by the `pathlib.Path` object.
Although `Path` object has `open()` method, 

Although the `Path` object also has an `open()` method, as noted in #83, pygrib uses C's `fopen()`, so this PR does not use the `open()` method, but simply converts the `Path` object to `str`.

Could you please review this?
It may not be so cool, so if you have a better way to do this, I would appreciate it if you could let me know.

Thanks a lot.

Closes #193.