### PR TITLE
Allow `pygrib.open` to accept an `io.BufferedReader` object

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,8 +1,10 @@
 since version 2.1.4 release
 ===========================
 * add __dir__ method so dir(grb) returns grib keys.
-* allow pygrib.open() to open the path specified by the pathlib.Path object
+* allow pygrib.open to open a path specified by a pathlib.Path object
   (issue #193, PR #204)
+* allow pygrib.open to take an io.BufferedReader object as an argument
+  (issue #83, PR #206)
 
 version 2.1.4 (git tag v2.1.4rel)
 ================================

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include utils/*grib*
 include Changelog
 recursive-include src *pyx
 recursive-include src *py
+recursive-include src *h
 recursive-include docs *
 recursive-include eccodes *.def
 recursive-include test *.py

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -83,8 +83,8 @@ cdef extern from "stdio.h":
     long ftell(FILE *)
     int SEEK_SET
 
-cdef extern from "unistd.h":
-    int dup(int)
+cdef extern from "./portable.h":
+    int wrap_dup(int)
 
 cdef extern from "Python.h":
     object PyBytes_FromStringAndSize(char *s, size_t size)
@@ -330,7 +330,7 @@ cdef class open(object):
         cdef grib_handle *gh
         cdef FILE *_fd
         if isinstance(filename, BufferedReader):
-            fileno = dup(filename.fileno())
+            fileno = wrap_dup(filename.fileno())
             self._fd = fdopen(fileno, "rb")
             self._offset = filename.tell()
             self._inner = filename

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -329,6 +329,12 @@ cdef class open(object):
             fileno = dup(filename.fileno())
             self._fd = fdopen(fileno, "rb")
             self._offset = filename.tell()
+            # since BufferedReader has its own read buffer,
+            # BufferedReader.seek() sometimes just changes its
+            # internal position and BufferedReader.tell() returns
+            # a calculated value, we need to ensure the actual
+            # position by fseek().
+            fseek(self._fd, self._offset, SEEK_SET)
         else:
             if isinstance(filename, Path):
                 filename = str(filename)

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -296,9 +296,11 @@ def get_definitions_path():
 
 cdef class open(object):
     """ 
-    open(filename_or_path)
+    open(filepath_or_buffer)
 
-    returns GRIB file iterator object given GRIB filename or a Path object. When iterated, returns
+    returns GRIB file iterator object given GRIB file path (:py:class:`str` or
+    :py:class:`pathlib.Path` object) or buffer (:py:class:`io.BufferedReader` object).
+    When iterated, returns
     instances of the :py:class:`gribmessage` class. Behaves much like a python file
     object, with :py:meth:`seek`, :py:meth:`tell`, :py:meth:`read`
     :py:meth:`readline` and :py:meth:`close` methods

--- a/src/pygrib/portable.h
+++ b/src/pygrib/portable.h
@@ -1,0 +1,16 @@
+#ifndef _PYGRIB_PORTABLE_H_
+#define _PYGRIB_PORTABLE_H_
+
+#ifdef _WIN32
+
+#include <io.h>
+#define wrap_dup _dup
+
+#else
+
+#include <unistd.h>
+#define wrap_dup dup
+
+#endif  /* _WIN32 */
+
+#endif  /* _PYGRIB_PORTABLE_H_ */

--- a/test/test.py
+++ b/test/test.py
@@ -244,6 +244,27 @@ def test():
     >>> from pathlib import Path
     >>> grbs = pygrib.open(Path.cwd().parent / 'sampledata' / 'flux.grb')
     >>> assert type(grbs.name) == str
+
+    test opening a file from a file object
+    >>> f = open('../sampledata/flux.grb', 'rb')
+    >>> grbs = pygrib.open(f)
+    >>> for grb in grbs: print(grb)
+    1:Precipitation rate:kg m**-2 s**-1 (avg):regular_gg:surface:level 0:fcst time 108-120 hrs (avg):from 200402291200
+    2:Surface pressure:Pa (instant):regular_gg:surface:level 0:fcst time 120 hrs:from 200402291200
+    3:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
+    4:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
+    >>> print(grbs.name)
+    ../sampledata/flux.grb
+    >>> grbs.close()
+    >>> f.close()
+
+    test opening a file from a BytesIO object
+    >>> from io import BytesIO
+    >>> with open('../sampledata/flux.grb', 'rb') as f: data = f.read()
+    >>> f = BytesIO(data)
+    >>> grbs = pygrib.open(f)
+    Traceback (most recent call last):
+    TypeError: expected bytes, _io.BytesIO found
     """
 
 if __name__ == "__main__":

--- a/test/test.py
+++ b/test/test.py
@@ -239,32 +239,6 @@ def test():
     >>> str(grb.packingType)
     'grid_simple'
     >>> grbs.close()
-
-    test opening a file specified by a pathlib.Path object
-    >>> from pathlib import Path
-    >>> grbs = pygrib.open(Path.cwd().parent / 'sampledata' / 'flux.grb')
-    >>> assert type(grbs.name) == str
-
-    test opening a file from a file object
-    >>> f = open('../sampledata/flux.grb', 'rb')
-    >>> grbs = pygrib.open(f)
-    >>> for grb in grbs: print(grb)
-    1:Precipitation rate:kg m**-2 s**-1 (avg):regular_gg:surface:level 0:fcst time 108-120 hrs (avg):from 200402291200
-    2:Surface pressure:Pa (instant):regular_gg:surface:level 0:fcst time 120 hrs:from 200402291200
-    3:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
-    4:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
-    >>> print(grbs.name)
-    ../sampledata/flux.grb
-    >>> grbs.close()
-    >>> f.close()
-
-    test opening a file from a BytesIO object
-    >>> from io import BytesIO
-    >>> with open('../sampledata/flux.grb', 'rb') as f: data = f.read()
-    >>> f = BytesIO(data)
-    >>> grbs = pygrib.open(f)
-    Traceback (most recent call last):
-    TypeError: expected bytes, _io.BytesIO found
     """
 
 if __name__ == "__main__":

--- a/test/test_open.py
+++ b/test/test_open.py
@@ -102,12 +102,7 @@ def reread_end_section_using_raw_file_access(f):
 @pytest.mark.parametrize(
     "preprocess, print_result_expected, postprocess",
     [
-        pytest.param(
-            read_indicator,
-            print_result_expected_for_data_with_offset,
-            None,
-            marks=pytest.mark.xfail(reason="bug"),
-        ),
+        (read_indicator, print_result_expected_for_data_with_offset, None,),
         pytest.param(
             read_indicator_and_seek_to_starting_point,
             print_result_expected_for_messages,

--- a/test/test_open.py
+++ b/test/test_open.py
@@ -1,0 +1,65 @@
+from io import BytesIO
+from pathlib import Path
+import os
+
+import pygrib
+import pytest
+
+filename = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "../sampledata/flux.grb"
+)
+
+print_result_expected_for_messages = """
+1:Precipitation rate:kg m**-2 s**-1 (avg):regular_gg:surface:level 0:fcst time 108-120 hrs (avg):from 200402291200
+2:Surface pressure:Pa (instant):regular_gg:surface:level 0:fcst time 120 hrs:from 200402291200
+3:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
+4:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
+""".lstrip()
+
+
+def assert_print_result(grbs, capsys, expected):
+    for grb in grbs:
+        print(grb)
+    captured = capsys.readouterr()
+    assert captured.out == expected
+
+
+def run_print_assertions(grbs, capsys):
+    assert_print_result(grbs, capsys, print_result_expected_for_messages)
+    assert_print_result(grbs, capsys, "")
+    grbs.seek(0)
+    assert_print_result(grbs, capsys, print_result_expected_for_messages)
+
+
+def test_open_for_filename(capsys):
+    grbs = pygrib.open(filename)
+    assert type(grbs.name) == str
+    run_print_assertions(grbs, capsys)
+    grbs.close()
+
+
+def test_open_for_path_object(capsys):
+    path = Path(filename)
+    grbs = pygrib.open(path)
+    assert type(grbs.name) == str
+    run_print_assertions(grbs, capsys)
+    grbs.close()
+
+
+def test_open_for_bufferedreader_object(capsys):
+    f = open(filename, "rb")
+    grbs = pygrib.open(f)
+    assert type(grbs.name) == str
+    run_print_assertions(grbs, capsys)
+    grbs.close()
+    f.close()
+
+
+def test_open_for_bytesio_object(capsys):
+    with open(filename, "rb") as f:
+        buffer = f.read()
+    f = BytesIO(buffer)
+
+    with pytest.raises(TypeError) as e:
+        pygrib.open(f)
+    assert str(e.value) == "expected bytes, _io.BytesIO found"

--- a/test/test_open.py
+++ b/test/test_open.py
@@ -103,11 +103,10 @@ def reread_end_section_using_raw_file_access(f):
     "preprocess, print_result_expected, postprocess",
     [
         (read_indicator, print_result_expected_for_data_with_offset, None,),
-        pytest.param(
+        (
             read_indicator_and_seek_to_starting_point,
             print_result_expected_for_messages,
             None,
-            marks=pytest.mark.xfail(reason="bug"),
         ),
         (
             None,

--- a/test/test_open.py
+++ b/test/test_open.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+from io import BytesIO, SEEK_CUR
 from pathlib import Path
 import os
 
@@ -14,6 +14,12 @@ print_result_expected_for_messages = """
 2:Surface pressure:Pa (instant):regular_gg:surface:level 0:fcst time 120 hrs:from 200402291200
 3:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
 4:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
+""".lstrip()
+
+print_result_expected_for_data_with_offset = """
+1:Surface pressure:Pa (instant):regular_gg:surface:level 0:fcst time 120 hrs:from 200402291200
+2:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
+3:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
 """.lstrip()
 
 
@@ -55,11 +61,129 @@ def test_open_for_bufferedreader_object(capsys):
     f.close()
 
 
+@pytest.mark.xfail(reason="unimplemented")
 def test_open_for_bytesio_object(capsys):
     with open(filename, "rb") as f:
         buffer = f.read()
     f = BytesIO(buffer)
+    grbs = pygrib.open(f)
+    assert type(grbs.name) == str
+    run_print_assertions(grbs, capsys)
+    grbs.close()
+    f.close()
+
+
+def test_open_for_textiowrapper_object():
+    f = open(filename, "r")
 
     with pytest.raises(TypeError) as e:
         pygrib.open(f)
-    assert str(e.value) == "expected bytes, _io.BytesIO found"
+    assert str(e.value) == "expected bytes, _io.TextIOWrapper found"
+
+
+INDICATOR = b"GRIB"
+
+
+def read_indicator(f):
+    assert f.read(len(INDICATOR)) == INDICATOR
+
+
+def read_indicator_and_seek_to_starting_point(f):
+    read_indicator(f)
+    f.seek(-len(INDICATOR), SEEK_CUR)
+
+
+def reread_end_section_using_raw_file_access(f):
+    end_section_bytes = b"7777"
+    f.seek(-len(end_section_bytes), SEEK_CUR)
+    assert f.read(len(end_section_bytes)) == end_section_bytes
+
+
+@pytest.mark.parametrize(
+    "preprocess, print_result_expected, postprocess",
+    [
+        pytest.param(
+            read_indicator,
+            print_result_expected_for_data_with_offset,
+            None,
+            marks=pytest.mark.xfail(reason="bug"),
+        ),
+        pytest.param(
+            read_indicator_and_seek_to_starting_point,
+            print_result_expected_for_messages,
+            None,
+            marks=pytest.mark.xfail(reason="bug"),
+        ),
+        (
+            None,
+            print_result_expected_for_messages,
+            reread_end_section_using_raw_file_access,
+        ),
+        pytest.param(
+            read_indicator_and_seek_to_starting_point,
+            print_result_expected_for_messages,
+            reread_end_section_using_raw_file_access,
+            marks=pytest.mark.xfail(reason="bug"),
+        ),
+    ],
+)
+def test_open_for_bufferedreader_object_with_raw_file_reading(
+    capsys, preprocess, print_result_expected, postprocess
+):
+    f = open(filename, "rb")
+
+    if preprocess is not None:
+        preprocess(f)
+
+    grbs = pygrib.open(f)
+    assert_print_result(grbs, capsys, print_result_expected)
+    grbs.seek(0)
+    assert_print_result(grbs, capsys, print_result_expected)
+    grbs.close()
+
+    if postprocess is not None:
+        postprocess(f)
+    f.close()
+
+
+@pytest.mark.parametrize(
+    "preprocess, print_result_expected, postprocess",
+    [
+        (read_indicator, print_result_expected_for_data_with_offset, None,),
+        (
+            read_indicator_and_seek_to_starting_point,
+            print_result_expected_for_messages,
+            None,
+        ),
+        (
+            None,
+            print_result_expected_for_messages,
+            reread_end_section_using_raw_file_access,
+        ),
+        (
+            read_indicator_and_seek_to_starting_point,
+            print_result_expected_for_messages,
+            reread_end_section_using_raw_file_access,
+        ),
+    ],
+)
+@pytest.mark.xfail(reason="unimplemented")
+def test_open_for_bytesio_object_with_raw_file_reading(
+    capsys, preprocess, print_result_expected, postprocess
+):
+    with open(filename, "rb") as f:
+        buffer = f.read()
+    f = BytesIO(buffer)
+
+    if preprocess is not None:
+        preprocess(f)
+
+    grbs = pygrib.open(f)
+    assert_print_result(grbs, capsys, print_result_expected)
+    grbs.seek(0)
+    assert_print_result(grbs, capsys, print_result_expected)
+    grbs.close()
+
+    if postprocess is not None:
+        postprocess(f)
+    f.close()

--- a/test/test_open.py
+++ b/test/test_open.py
@@ -126,11 +126,10 @@ def reread_end_section_using_raw_file_access(f):
             message_lines_expected_for_data_with_zero_offset,
             reread_end_section_using_raw_file_access,
         ),
-        pytest.param(
+        (
             read_indicator_and_seek_to_starting_point,
             message_lines_expected_for_data_with_zero_offset,
             reread_end_section_using_raw_file_access,
-            marks=pytest.mark.xfail(reason="bug"),
         ),
     ],
 )


### PR DESCRIPTION
This PR enhances `pygrib.open` to take an `io.BufferedReader` object as an argument.

The `io.BufferedReader` objects are so-called file objects (#83), but I believe file objects also include `io.BytesIO` objects, which reads from Python bytes. In this PR, only reading from `io.BufferedReader` objects, which read from file systems, is supported.

If there is a problem with the following design in the first place, or if there is an implementation problem, I would appreciate it if you could let me know.

Many thanks.

### Design

When a user give an `io.BufferedReader` object `f` to `pygrib.open()` instead of the path of the GRIB file, the user usually has done something like `f.read(some_bytes)` or `f.seek(some_pos)` beforehand and thus the position has changed from the start position of the buffer. The user wants to read the GRIB from there. Therefore, in this PR, the position of `f` at the timing given to `pygrib.open()` is held in the instance, and that offset is used in operations in `pygrib.open`. Also, when `pygrib.open.close()` is called, the position in `pygrib.open` is set to `f` again.
