### PR TITLE
Fix macOS compile with newer clang

### DIFF
--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -140,14 +140,14 @@ cdef extern from "grib_api.h":
     int grib_set_string(grib_handle *h, char *name, char *mesg, size_t *size)
     grib_keys_iterator* grib_keys_iterator_new(grib_handle* h,unsigned long filter_flags, char* name_space)
     int grib_keys_iterator_next(grib_keys_iterator *kiter)
-    char* grib_keys_iterator_get_name(grib_keys_iterator *kiter)
+    const char* grib_keys_iterator_get_name(grib_keys_iterator *kiter)
     int grib_handle_delete(grib_handle* h)
     grib_handle* grib_handle_new_from_file(grib_context* c, FILE* f, int* error)        
-    char* grib_get_error_message(int code)
+    const char* grib_get_error_message(int code)
     int grib_keys_iterator_delete( grib_keys_iterator* kiter)
     void grib_multi_support_on(grib_context* c)
     void grib_multi_support_off(grib_context* c)
-    int grib_get_message(grib_handle* h ,  void** message,size_t *message_length)
+    int grib_get_message(grib_handle* h , const void** message,size_t *message_length)
     int grib_get_message_copy(grib_handle* h ,  void* message,size_t *message_length)
     long grib_get_api_version()
     grib_handle* grib_handle_clone(grib_handle* h)
@@ -979,7 +979,7 @@ cdef class gribmessage(object):
         """
         cdef grib_keys_iterator* gi
         cdef int err, typ
-        cdef char *name
+        cdef const char *name
         # use cached keys if they exist.
         if self._all_keys is not None: return self._all_keys
         # if not, get keys from grib file.
@@ -1015,7 +1015,7 @@ cdef class gribmessage(object):
         """
         cdef grib_keys_iterator* gi
         cdef int err, typ
-        cdef char *name
+        cdef const char *name
         if self._all_keys is None:
             self._all_keys = self.keys()
         gi = grib_keys_iterator_new(self._gh,\
@@ -1253,7 +1253,7 @@ cdef class gribmessage(object):
         """
         cdef int err
         cdef size_t size
-        cdef void *message
+        cdef const void *message
         cdef char *name
         cdef FILE *out
         bytestr = b'values'

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -12,7 +12,7 @@ from pathlib import Path
 from pkg_resources import parse_version
 from numpy import ma
 import pyproj
-import_array()
+npc.import_array()
 
 cdef _redtoreg(object nlonsin, npc.ndarray lonsperlat, npc.ndarray redgrid, \
               object missval):
@@ -99,10 +99,8 @@ cdef extern from "numpy/arrayobject.h":
         cdef npy_intp *strides
         cdef object base
         cdef int flags
-    npy_intp PyArray_SIZE(ndarray arr)
     npy_intp PyArray_ISCONTIGUOUS(ndarray arr)
     npy_intp PyArray_ISALIGNED(ndarray arr)
-    void import_array()
 
 cdef extern from "grib_api.h":
     ctypedef struct grib_handle


### PR DESCRIPTION
This fixes up a [compiler error seen on conda-forge](https://github.com/conda-forge/pygrib-feedstock/issues/55) with >=v15 of the Mac compilers, stemming from:

```
 src/pygrib/_pygrib.c:44829:3: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion]
    import_array();
    ^~~~~~~~~~~~~~
  /Users/runner/miniforge3/conda-bld/pygrib_1698064180141/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.10/site-packages/numpy/core/include/numpy/__multiarray_api.h:1545:151: note: expanded from macro 'import_array'
  #define import_array() {if (_import_array() < 0) {PyErr_Print(); PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import"); return NULL; } }
                                                                                                                                                        ^~~~
  /Users/runner/miniforge3/conda-bld/pygrib_1698064180141/_build_env/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
  #  define NULL ((void*)0)
                 ^~~~~~~~~~
```

I see this building git locally, but only as a warning. Regardless, it seems easier to just call the Python function in the API instead of the macro.

I also fixed up some `const` warnings, including updating a few function devs from upstream.