### PR TITLE
Silence CI warnings on node12 deprecation

### DIFF
--- a/.github/workflows/build-conda.yml
+++ b/.github/workflows/build-conda.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest  
             platform: x32
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Conda
       uses: s-weigand/setup-conda@v1

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest  
             platform: x32
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Conda
       uses: s-weigand/setup-conda@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: ["3.9"]
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
This PR updates `action/checkout` from v2 to v4 to silence warnings on node12 deprecation.

Many thanks.