### PR TITLE
Move static project metadata to pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         FFLAGS="-fallow-argument-mismatch" pip install --no-use-pep517 pyspharm
         # for later building/checking
         pip install build twine
-        pip install cython check-manifest
+        pip install check-manifest
         # below here only needed for mpl/cartopy based tests
         pip install pytest-mpl
         pip install cartopy

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+build/
+*.pyc
+dist/
+*.egg-info/
+src/pygrib/_pygrib.c
+src/pygrib/*.so
+test/out.grib
+venv/
+.eggs/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Install and Test Status](https://github.com/jswhit/pygrib/workflows/Install%20and%20Test/badge.svg)](https://github.com/jswhit/pygrib/actions)
+[![Install and Test Status](https://github.com/jswhit/pygrib/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/jswhit/pygrib/actions)
 [![PyPI package](https://badge.fury.io/py/pygrib.svg)](http://python.org/pypi/pygrib)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pygrib/badges/version.svg)](https://anaconda.org/conda-forge/pygrib)
 [![DOI](https://zenodo.org/badge/28599617.svg)](https://zenodo.org/badge/latestdoi/28599617)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,55 @@
 [build-system]
-# minimum requiremets for build system
-requires = ["setuptools", "cython", "numpy", "wheel"]
+requires = [
+    "Cython>=0.29",
+    "oldest-supported-numpy",
+    "setuptools>=61",
+]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "pygrib"
+description = "Python module for reading/writing GRIB files"
+readme = "README.md"
+authors = [
+  {name = "Jeff Whitaker", email = "jeffrey.s.whitaker@noaa.gov"},
+]
+requires-python = ">=3.7"
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "pyproj",
+    "numpy",
+]
+dynamic = ["version"]
+
+[project.urls]
+Documentation = "https://jswhit.github.io/pygrib/"
+Repository = "https://github.com/jswhit/pygrib"
+
+[tool.check-manifest]
+ignore = [
+    ".gitignore",
+    "src/pygrib/*.c",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["test"]
+doctest_optionflags = ["NORMALIZE_WHITESPACE ELLIPSIS"]
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,0 @@
-[tool:pytest]
-testpaths = test
-doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
-
-[check-manifest]
-ignore =
-    .gitignore
-    src/pygrib/*.c

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-import os, sys
 import glob
+import os
 import setuptools
+import sys
 from Cython.Distutils import build_ext
 
 
@@ -97,11 +98,6 @@ ext_modules = [
     )
 ]
 
-# Import README.md as PyPi long_description
-this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, "README.md")) as f:
-    long_description = f.read()
-
 # man pages installed in MAN_DIR/man1
 if os.environ.get("MAN_DIR"):
     man_dir = os.environ.get("MAN_DIR")
@@ -111,31 +107,11 @@ if os.environ.get("MAN_DIR"):
 else:
     data_files = None
 
+# See pyproject.toml for project metadata
 setuptools.setup(
-    name="pygrib",
+    name="pygrib",  # need by GitHub dependency graph
     version=extract_version("src/pygrib/_pygrib.pyx"),
-    description="Python module for reading/writing GRIB files",
-    author="Jeff Whitaker",
-    author_email="jeffrey.s.whitaker@noaa.gov",
-    url="https://github.com/jswhit/pygrib",
-    download_url="http://python.org/pypi/pygrib",
-    license="License :: OSI Approved :: MIT License",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
     cmdclass=cmdclass,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
     scripts=[
         "utils/grib_list",
         "utils/grib_repack",
@@ -144,13 +120,5 @@ setuptools.setup(
     ],
     ext_modules=ext_modules,
     data_files=data_files,
-    packages=["pygrib"],
-    package_dir={'':'src'},
     package_data=package_data,
-    setup_requires=["setuptools", "cython"],
-    install_requires=[
-        "pyproj",
-        "setuptools",
-        "numpy",
-    ],
 )


### PR DESCRIPTION
This PR moves static project metadata to pyproject.toml, removing setup.cfg and clearing up setup.py a bit.

Also, update a few useful URLs to repo and docs, clean up some old Python version classifiers, add a .gitignore file.

I noticed that [build.yml](https://github.com/jswhit/pygrib/actions/workflows/build.yml) was "disabled manually"; it can be re-enabled, as there was a fix from #223 to make it work. This build is used for the CI status on the README.md page. (Unless another build status should be used instead, suggestions welcome).