### PR TITLE
Switch dynamic version handling from pkg_resources (in setuptools) to packaging

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+since version 2.1.5 release
+===========================
+* switch dynamic version handling from pkg_resources (in setuptools) to packaging
+
 version 2.1.5 release
 =====================
 * remove python 3.6 support, add python 3.11,3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "packaging",
     "pyproj",
     "numpy",
 ]

--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -9,7 +9,7 @@ import os
 from datetime import datetime
 from io import BufferedReader
 from os import PathLike
-from pkg_resources import parse_version
+from packaging import version
 from numpy import ma
 import pyproj
 npc.import_array()
@@ -1391,7 +1391,7 @@ cdef class gribmessage(object):
                 else:
                     scalea = 1.
                     scaleb = 1.
-                if parse_version(grib_api_version) < parse_version('1.9.0'):
+                if version.parse(grib_api_version) < version.parse('1.9.0'):
                     projparams['a']=self['scaledValueOfMajorAxisOfOblateSpheroidEarth']*scalea
                     projparams['b']=self['scaledValueOfMinorAxisOfOblateSpheroidEarth']*scaleb
                 else:


### PR DESCRIPTION
This PR fixes `ModuleNotFoundError` resulting from missing dependency on setuptools.

In the executable code of pygrib, setuptools is only used for version comparison purposes, and since setuptools is larger than necessary, this commit replaces it with packaging, which is a more compact module containing reusable core utilities for Python packaging compliant with recent PEPs.

Closes #228.