### PR TITLE
issue265-arm64 from ctypes import c_long as long

### DIFF
--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -5,6 +5,7 @@ __version__ = '2.1.6'
 import numpy as np
 cimport numpy as npc
 cimport cython
+from ctypes import c_long as long
 import warnings
 import os
 from datetime import datetime


### PR DESCRIPTION
For linux on arm64 the `long` type is not defined, so grab it from `ctypes.c_long`