### PR TITLE
Declare wheel and pip as build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "setuptools>=61",
     "oldest-supported-numpy ; python_version < '3.9'",
     "numpy>=2.0.0rc1,<3 ; python_version >= '3.9'",
+    "wheel",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     "oldest-supported-numpy ; python_version < '3.9'",
     "numpy>=2.0.0rc1,<3 ; python_version >= '3.9'",
     "wheel",
+    "pip",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Workaround to allow pip install with build isolation