### PR TITLE
Fix compatibility with Cython >= 3.1

### DIFF
--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -5,7 +5,6 @@ __version__ = '2.1.6'
 import numpy as np
 cimport numpy as npc
 cimport cython
-from ctypes import c_long as long
 import warnings
 import os
 from datetime import datetime
@@ -423,7 +422,7 @@ cdef class open(object):
             grbs = [self.message(n) for n in xrange(beg,end,inc)]
             self.seek(msg) # put iterator back in original position
             return grbs
-        elif type(key) == int or type(key) == long:
+        elif type(key) == int:
             # for an integer, return a single grib message.
             msg = self.tell()
             grb = self.message(key)
@@ -1924,8 +1923,8 @@ Example usage:
             # if there are no matches for this key, just skip it
             if not size:
                 continue
-            if typ == 'l' or (type(v) == int or type(v) == long):
-                longval = long(v)
+            if typ == 'l' or (type(v) == int):
+                longval = int(v)
                 err = grib_index_select_long(self._gi, key, longval)
                 if err:
                     raise RuntimeError(_get_error_message(err))


### PR DESCRIPTION
Hello, I'm one of the Cython maintainers on Fedora.

When doing an impact test for updating from Cython 3.0.12 to 3.1.2, pygrib failed to build so I tried using https://github.com/jswhit/pygrib/pull/266. While the package built, various tests failed:

<details>

<summary>Snippet of failed tests</summary>

**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 98, in __main__.test

Failed example:
    selgrbs = grbindx(name='Minimum temperature',level=2,typeOfLevel='heightAboveGround')
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[36]>", line 1, in <module>
        selgrbs = grbindx(name='Minimum temperature',level=2,typeOfLevel='heightAboveGround')
      File "src/pygrib/_pygrib.pyx", line 1879, in pygrib._pygrib.index.__call__
      File "src/pygrib/_pygrib.pyx", line 1932, in pygrib._pygrib.index.select
    TypeError: an integer is required
Trying:
    for grb in selgrbs: grb
Expecting:
    1:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200

**********************************************************************

File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 99, in __main__.test
Failed example:
    for grb in selgrbs: grb
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[37]>", line 1, in <module>
        for grb in selgrbs: grb
                   ^^^^^^^
    NameError: name 'selgrbs' is not defined
Trying:
    selgrbs = grbindx(name='Maximum temperature',level=2,typeOfLevel='heightAboveGround')
Expecting nothing
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 101, in __main__.test
Failed example:
    selgrbs = grbindx(name='Maximum temperature',level=2,typeOfLevel='heightAboveGround')
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[38]>", line 1, in <module>
        selgrbs = grbindx(name='Maximum temperature',level=2,typeOfLevel='heightAboveGround')
      File "src/pygrib/_pygrib.pyx", line 1879, in pygrib._pygrib.index.__call__
      File "src/pygrib/_pygrib.pyx", line 1932, in pygrib._pygrib.index.select
    TypeError: an integer is required
Trying:
    for grb in selgrbs: grb
Expecting:
    1:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 102, in __main__.test
Failed example:
    for grb in selgrbs: grb
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[39]>", line 1, in <module>
        for grb in selgrbs: grb
                   ^^^^^^^
    NameError: name 'selgrbs' is not defined
Trying:
    grbindx.write('flux.grb.idx') # save the index
Expecting nothing
ok
Trying:
    grbindx.close()
Expecting nothing
ok
Trying:
    grbindx = pygrib.index('flux.grb.idx')
Expecting nothing
ok
Trying:
    selgrbs = grbindx(name='Minimum temperature',level=2,typeOfLevel='heightAboveGround')
Expecting nothing
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 109, in __main__.test
Failed example:
    selgrbs = grbindx(name='Minimum temperature',level=2,typeOfLevel='heightAboveGround')
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[43]>", line 1, in <module>
        selgrbs = grbindx(name='Minimum temperature',level=2,typeOfLevel='heightAboveGround')
      File "src/pygrib/_pygrib.pyx", line 1879, in pygrib._pygrib.index.__call__
      File "src/pygrib/_pygrib.pyx", line 1932, in pygrib._pygrib.index.select
    TypeError: an integer is required
Trying:
    for grb in selgrbs: grb
Expecting:
    1:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 110, in __main__.test
Failed example:
    for grb in selgrbs: grb
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[44]>", line 1, in <module>
        for grb in selgrbs: grb
                   ^^^^^^^
    NameError: name 'selgrbs' is not defined
Trying:
    selgrbs = grbindx(name='Maximum temperature',level=2,typeOfLevel='heightAboveGround')
Expecting nothing
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 112, in __main__.test
Failed example:
    selgrbs = grbindx(name='Maximum temperature',level=2,typeOfLevel='heightAboveGround')
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[45]>", line 1, in <module>
        selgrbs = grbindx(name='Maximum temperature',level=2,typeOfLevel='heightAboveGround')
      File "src/pygrib/_pygrib.pyx", line 1879, in pygrib._pygrib.index.__call__
      File "src/pygrib/_pygrib.pyx", line 1932, in pygrib._pygrib.index.select
    TypeError: an integer is required
Trying:
    for grb in selgrbs: grb
Expecting:
    1:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 113, in __main__.test
Failed example:
    for grb in selgrbs: grb
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[46]>", line 1, in <module>
        for grb in selgrbs: grb
                   ^^^^^^^
    NameError: name 'selgrbs' is not defined
Trying:
    grbindx.close()
Expecting nothing
ok
Trying:
    grb = selgrbs[0]
Expecting nothing
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 117, in __main__.test
Failed example:
    grb = selgrbs[0]
Exception raised:
    Traceback (most recent call last):
      File "<doctest __main__.test[48]>", line 1, in <module>
        grb = selgrbs[0]
              ^^^^^^^
    NameError: name 'selgrbs' is not defined
Trying:
    grb
Expecting:
    1:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
**********************************************************************
File "/builddir/build/BUILD/pygrib-2.1.6-build/pygrib-2.1.6-tmp-test/test/test.py", line 118, in __main__.test
Failed example:
    grb
Expected:
    1:Maximum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
Got:
    4:Minimum temperature:K (instant):regular_gg:heightAboveGround:level 2 m:fcst time 108-120 hrs:from 200402291200
Trying:
    data = grb['values'] # 'values' returns the data
Expecting nothing
ok

</details>

It seems as if https://github.com/jswhit/pygrib/pull/266 did not have the intended effects, at least on our OS. However an appropriate fix would be to remove the mentions of "long" as it was only there to support Python 2 and it was removed in Cython 3.1.

This PR makes pygrib compile with Cython 3.1.2 and all the tests pass. It works for lower Cython versions as well.

See also: https://github.com/cython/cython/pull/5830 and https://github.com/kivy/pyjnius/pull/756

Fixes https://github.com/jswhit/pygrib/issues/265