### PR TITLE
Optimize latlons() for regular_ll and regular_gg grids for grib2

### DIFF
--- a/src/pygrib/_pygrib.pyx
+++ b/src/pygrib/_pygrib.pyx
@@ -1584,13 +1584,52 @@ cdef class gribmessage(object):
             raise ValueError('unsupported grid %s' % self['gridType'])
 
         if self['gridType'] in ['regular_gg','regular_ll']: # regular lat/lon grid
-            lat1 = self['latitudeOfFirstGridPointInDegrees']
-            lat2 = self['latitudeOfLastGridPointInDegrees']
-            lats = self['distinctLatitudes']
-            if self['Nj'] > 1:
-                if lat2 < lat1 and lats[-1] > lats[0]: lats = lats[::-1]
-            lons = self['distinctLongitudes']
-            lons,lats = np.meshgrid(lons,lats) 
+            lons = None
+            lats = None
+            # try to calculate the lons, lats rather than relying on the (much slower) distinct lats/lons call
+            try:
+                grid_type = self['gridType']
+                if grid_type in ['regular_ll', 'regular_gg']:
+                    j_points_consec = self['jPointsAreConsecutive'] if self.has_key('jPointsAreConsecutive') else 0
+                    # only for row-major matrix layout
+                    if j_points_consec == 0:
+                        ni, nj = int(self['Ni']), int(self['Nj'])
+                        lat_start = float(self['latitudeOfFirstGridPointInDegrees'])
+                        lon_start = float(self['longitudeOfFirstGridPointInDegrees'])
+                        lat_end = float(self['latitudeOfLastGridPointInDegrees'])
+                        lon_end = float(self['longitudeOfLastGridPointInDegrees'])
+                        i_scans_neg = self['iScansNegatively'] if self.has_key('iScansNegatively') else 0
+                        j_scans_pos = self['jScansPositively'] if self.has_key('jScansPositively') else 0
+                        di = float(self['iDirectionIncrementInDegrees'])
+                        lon_step = -di if i_scans_neg else di
+                        calc_lons = lon_start + np.arange(ni) * lon_step
+                        if lon_start > 180 and lon_end <= 360:
+                            calc_lons = (calc_lons + 180) % 360 - 180
+                        # handle (intended) anti-meridian global wraps when the first lon has the wrong sign
+                        if abs(lon_start) == 180.0:
+                            if (lon_step > 0 and lon_end < 180.0) or (lon_step < 0 and lon_end > -180.0):
+                                calc_lons = (calc_lons + 180.0) % 360.0 - 180.0
+                        if grid_type == 'regular_ll':
+                            dj = float(self['jDirectionIncrementInDegrees'])
+                            lat_step = dj if j_scans_pos else -dj
+                            calc_lats = lat_start + np.arange(nj) * lat_step
+                        else:  # regular_gg
+                            calc_lats = gaulats(nj)
+                            if j_scans_pos:
+                                calc_lats = calc_lats[::-1]
+                        lons, lats = np.meshgrid(calc_lons, calc_lats)
+            except Exception as e:
+                lons = None
+                lats = None
+            # fallback
+            if lats is None or lons is None:
+                lat1 = self['latitudeOfFirstGridPointInDegrees']
+                lat2 = self['latitudeOfLastGridPointInDegrees']
+                lats = self['distinctLatitudes']
+                if self['Nj'] > 1:
+                    if lat2 < lat1 and lats[-1] > lats[0]: lats = lats[::-1]
+                lons = self['distinctLongitudes']
+                lons,lats = np.meshgrid(lons,lats)
         elif self['gridType'] == 'reduced_gg': # reduced global gaussian grid
             if self.expand_reduced:
                 lat1 = self['latitudeOfFirstGridPointInDegrees']

--- a/test/test_latlons.py
+++ b/test/test_latlons.py
@@ -114,3 +114,42 @@ def test_redtoreg(samplegribfile,field):
     grb.expand_grid(False)
     fld_tst = redtoreg(grb.values, grb.pl, missval=grb.missingValue)
     assert np.allclose(fld,fld_tst)
+
+# test regular_ll and regular_gg
+@pytest.mark.parametrize("filename", ["gfs.grb", "flux.grb"])
+def test_optimized_latlons_numerical_identity(samplegribfile, filename):
+    """
+    Verify mathematical identity against legacy C-layer decoding,
+    while implicitly proving the fast track was utilized.
+    """
+    msg = samplegribfile.message(1)
+    
+    # get the latlons using the optimized pathway
+    lats_opt, lons_opt = msg.latlons()
+    
+    # delete 'gridType' from the private cache to force the next call to legacy.
+    if hasattr(msg, '_all_keys') and 'gridType' in msg._all_keys:
+        msg._all_keys.remove('gridType')
+        try:
+            lats_legacy, lons_legacy = msg.latlons()
+            np.testing.assert_allclose(lats_opt, lats_legacy, rtol=1e-6, atol=1e-6)
+            np.testing.assert_allclose(lons_opt, lons_legacy, rtol=1e-6, atol=1e-6)
+            
+        finally:
+            msg._all_keys.append('gridType')
+# Make sure grib1 is processed (since it will use the fallback)
+@pytest.mark.parametrize("filename", ["regular_latlon_surface.grib1"])
+def test_legacy_grib1_regular_ll_fallback(samplegribfile, filename):
+    """
+    Verify that real GRIB1 regular_ll files that lack standard 
+    high-level geometry keys gracefully fall back to the native 
+    ecCodes C-layer engine without raising errors.
+    """
+    msg = samplegribfile.message(1)
+    
+    lats, lons = msg.latlons()
+    
+    assert lats is not None
+    assert lons is not None
+    assert lats.shape == msg.values.shape
+    assert lons.shape == msg.values.shape


### PR DESCRIPTION
## Description
Speed-up (~10x) patch for latlon(), for narrow case of regular_ll and regular_gg in GRIB2 files. This patch does it by replacing the slower distinctLatitudes and distinctLongitudes calls with direct calculations.

## Details
It's my understanding that in eccodes the distinctLatitudes and distinctLongitudes first gets the lats and lons from the entire grid of lats and lons and then filtering them to the unique values; this is significantly slower with larger and larger grids.

Generating it ourselves requires some careful handling for wrapping conditions, when wrapping is actually intended, given the irregular nature of how sometimes the keys are set by the various centers.

For instance, in a few of the gribs I tested had a first lon point of +180.0 going eastward, but with the last gridpoint of +179.75 (the original code generates -180 to 179.75). This is handled by the block of if abs(lon_start) == 180.0 etc.
I also put handling for starting at -180 for the reverse case of this going westward even though I don't have a sample of it to confirm.

## Testing
I tested it against 24 varied GRIB files I had scattered about from some various products (i.e. from ECMWF,NCEP, CMC, UKMET, NAVGEM), but it definitely doesn't cover all the centers

**It is not exhaustive so use with care if you apply this patch.**

Further edge-case reports welcome.

## Further notes
For another project I had originally disk-cached (h5) the latlons() on all the relevant grib keys to access the latlons() faster to get the 10x speedup (i.e. benchmarked 10x from ECMWF 0.25 deg -- for larger grids it will be a greater speedup, and conversely for smaller grids the speedup will be more modest). It was worthwhile enough to share this PR.